### PR TITLE
2 capability to create signal within an effect

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,5 +5,6 @@ read_globals = {
   "vim",
   "describe",
   "it",
-  "assert"
+  "assert",
+  "before_each"
 }

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+	"Lua.diagnostics.disable": [
+		"different-requires"
+	],
+	"Lua.diagnostics.globals": [
+		"vim",
+		"describe",
+		"it",
+		"assert",
+		"before_each"
+	],
+	"Lua.workspace": {
+		"checkThirdParty": false
+	},
+	"Lua.telemetry": {
+		"enable": false
+	},
+	"Lua.runtime.version": "LuaJIT",
+	"Lua.workspace.checkThirdParty": false,
+	"Lua.workspace.library": [
+		"${3rd}/OpenResty/library"
+	]
+}

--- a/lua/react/core/effect-error-messages.lua
+++ b/lua/react/core/effect-error-messages.lua
@@ -1,0 +1,4 @@
+return {
+	INVALID_SIGNAL_CREATION = [[Don't create signals inside loops, conditions, or nested functions.
+Instead, always use signals at the top level of your effect function]],
+}

--- a/lua/react/core/effect-events.lua
+++ b/lua/react/core/effect-events.lua
@@ -1,0 +1,15 @@
+return {
+
+	-- runs before / after each render
+	BEFORE_RENDER = 'BEFORE_RENDER',
+	AFTER_RENDER = 'AFTER_RENDER',
+
+	-- runs before / after each re-render
+	-- following will not be executed in the first render of the effect
+	BEFORE_RE_RENDER = 'BEFORE_RE_RENDER',
+	AFTER_RE_RENDER = 'AFTER_RE_RENDER',
+
+	-- runs before / after only once at the first render
+	BEFORE_INIT_RENDER = 'BEFORE_INIT_RENDER',
+	AFTER_INIT_RENDER = 'AFTER_INIT_RENDER',
+}

--- a/lua/react/core/effect.lua
+++ b/lua/react/core/effect.lua
@@ -1,33 +1,82 @@
 local Stack = require('react.util.stack')
 local Set = require('react.util.set')
+local Event = require('react.util.event')
+local EffectEvents = require('react.core.effect-events')
+
+local errors = require('react.core.effect-error-messages')
+local log = require('react.util.log')
 
 local M = {
 	context = Stack:new(),
 }
 
 function M:new(callback)
+	log.debug('creating new effect')
+
 	assert(
 		callback and type(callback) == 'function',
 		'Callback function should be passed to effect'
 	)
 
-	local o = nil
-
-	o = {
-		signals = Set:new(),
-		callback = function()
-			M.context:push(o)
-
-			callback()
-
-			M.context:pop(o)
-		end,
-	}
-
+	local o = {}
 	setmetatable(o, self)
 	self.__index = self
 
+	local context_push_callback = function()
+		o.events:dispatch(EffectEvents.BEFORE_RENDER)
+
+		M.context:push(o)
+		callback()
+		M.context:pop(o)
+
+		o.events:dispatch(EffectEvents.AFTER_RENDER)
+	end
+
+	o.first_render = true
+	o.signals = Set:new()
+	o.signal_pointer = 1
+	o.events = Event:new()
+
+	-- wrap the callback only for the first render to identify the initial
+	-- render
+	---@diagnostic disable-next-line: duplicate-set-field
+	o.callback = function()
+		o.events:dispatch(EffectEvents.BEFORE_INIT_RENDER)
+		context_push_callback()
+		o.events:dispatch(EffectEvents.AFTER_INIT_RENDER)
+
+		---@diagnostic disable-next-line: duplicate-set-field
+		o.callback = function()
+			o.events:dispatch(EffectEvents.BEFORE_RE_RENDER)
+			context_push_callback()
+			o.events:dispatch(EffectEvents.AFTER_RE_RENDER)
+		end
+	end
+
+	o:register_default_ev_callbacks()
+
 	return o
+end
+
+function M:is_first_render()
+	return self.first_render
+end
+
+function M:get_signal()
+	log.debug('returning existing signal for the pointer', self.signal_pointer)
+
+	if self:is_first_render() then
+		return
+	end
+
+	local signal = self.signals:get(self.signal_pointer)
+
+	debug.traceback()
+	assert(signal, errors.INVALID_SIGNAL_CREATION)
+
+	self.signal_pointer = self.signal_pointer + 1
+
+	return signal
 end
 
 function M:add_signal(signal)
@@ -48,6 +97,27 @@ end
 
 function M:dispatch()
 	self.callback()
+end
+
+function M:signal_retrieve_validation()
+	assert(
+		(self.signal_pointer - 1) == self.signals:length(),
+		errors.INVALID_SIGNAL_CREATION
+	)
+end
+
+function M:register_default_ev_callbacks()
+	self.events:add_listener(EffectEvents.BEFORE_RE_RENDER, function()
+		self.signal_pointer = 1
+	end)
+
+	self.events:add_listener(EffectEvents.AFTER_INIT_RENDER, function()
+		self.first_render = false
+	end, { once = true })
+
+	--  self.events:add_listener(EffectEvents.AFTER_RE_RENDER, function()
+	--  M:signal_retrieve_validation()
+	--  end)
 end
 
 return M

--- a/lua/react/util/event.lua
+++ b/lua/react/util/event.lua
@@ -1,0 +1,52 @@
+local Set = require('react.util.set')
+
+local M = {}
+
+function M:new()
+	local o = {
+		listeners_map = {},
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+
+	return o
+end
+
+function M:add_listener(event, listener, opt)
+	if not self.listeners_map[event] then
+		self.listeners_map[event] = Set:new()
+	end
+
+	if opt and not opt.once then
+		self.listeners_map[event]:add(listener)
+		return
+	end
+
+	local this = self
+
+	self.listeners_map[event]:add(function(...)
+		listener(...)
+		this:remove_listener(event, listener)
+	end)
+end
+
+function M:remove_listener(event, listener)
+	self.listeners_map[event]:remove_by_value(listener)
+end
+
+function M:dispatch(event, ...)
+	local info = {
+		event = event,
+	}
+
+	if not self.listeners_map[event] then
+		return
+	end
+
+	for _, listener in self.listeners_map[event]:iter() do
+		listener(info, ...)
+	end
+end
+
+return M

--- a/lua/react/util/log.lua
+++ b/lua/react/util/log.lua
@@ -1,0 +1,168 @@
+-- log.lua
+--
+-- Inspired by rxi/log.lua
+-- Modified by tjdevries and can be found at github.com/tjdevries/vlog.nvim
+--
+-- This library is free software; you can redistribute it and/or modify it
+-- under the terms of the MIT license. See LICENSE for details.
+
+-- User configuration section
+local default_config = {
+	-- Name of the plugin. Prepended to log messages
+	plugin = 'nvim-react',
+
+	-- Should print the output to neovim while running
+	use_console = true,
+
+	-- Should highlighting be used in console (using echohl)
+	highlights = true,
+
+	-- Should write to a file
+	use_file = false,
+
+	-- Any messages above this level will be logged.
+	level = vim.fn.environ().LOG_LEVEL or 'error',
+
+	-- Level configuration
+	modes = {
+		{ name = 'trace', hl = 'Comment' },
+		{ name = 'debug', hl = 'Comment' },
+		{ name = 'info', hl = 'None' },
+		{ name = 'warn', hl = 'WarningMsg' },
+		{ name = 'error', hl = 'ErrorMsg' },
+		{ name = 'fatal', hl = 'ErrorMsg' },
+	},
+
+	-- Can limit the number of decimals displayed for floats
+	float_precision = 0.01,
+}
+
+-- {{{ NO NEED TO CHANGE
+local log = {}
+
+local unpack = unpack or table.unpack
+
+log.new = function(config, standalone)
+	config = vim.tbl_deep_extend('force', default_config, config)
+
+	local outfile = string.format(
+		'%s/%s.log',
+		vim.api.nvim_call_function('stdpath', { 'data' }),
+		config.plugin
+	)
+
+	local obj
+	if standalone then
+		obj = log
+	else
+		obj = {}
+	end
+
+	local levels = {}
+	for i, v in ipairs(config.modes) do
+		levels[v.name] = i
+	end
+
+	local round = function(x, increment)
+		increment = increment or 1
+		x = x / increment
+		return (x > 0 and math.floor(x + 0.5) or math.ceil(x - 0.5)) * increment
+	end
+
+	local make_string = function(...)
+		local t = {}
+		for i = 1, select('#', ...) do
+			local x = select(i, ...)
+
+			if type(x) == 'number' and config.float_precision then
+				x = tostring(round(x, config.float_precision))
+			elseif type(x) == 'table' then
+				x = vim.inspect(x)
+			else
+				x = tostring(x)
+			end
+
+			t[#t + 1] = x
+		end
+		return table.concat(t, ' ')
+	end
+
+	local log_at_level = function(level, level_config, message_maker, ...)
+		-- Return early if we're below the config.level
+		if level < levels[config.level] then
+			return
+		end
+		local nameupper = level_config.name:upper()
+
+		local msg = message_maker(...)
+		local info = debug.getinfo(2, 'Sl')
+		local lineinfo = info.short_src .. ':' .. info.currentline
+
+		-- Output to console
+		if config.use_console then
+			local console_string = string.format(
+				'[%-6s%s] %s: %s',
+				nameupper,
+				os.date('%H:%M:%S'),
+				lineinfo,
+				msg
+			)
+
+			if config.highlights and level_config.hl then
+				vim.cmd(string.format('echohl %s', level_config.hl))
+			end
+
+			local split_console = vim.split(console_string, '\n')
+			for _, v in ipairs(split_console) do
+				vim.cmd(
+					string.format(
+						[[echom "[%s] %s"]],
+						config.plugin,
+						vim.fn.escape(v, '"')
+					)
+				)
+			end
+
+			if config.highlights and level_config.hl then
+				vim.cmd('echohl NONE')
+			end
+		end
+
+		-- Output to log file
+		if config.use_file then
+			local fp = io.open(outfile, 'a')
+			local str = string.format(
+				'[%-6s%s] %s: %s\n',
+				nameupper,
+				os.date(),
+				lineinfo,
+				msg
+			)
+			fp:write(str)
+			fp:close()
+		end
+	end
+
+	for i, x in ipairs(config.modes) do
+		obj[x.name] = function(...)
+			return log_at_level(i, x, make_string, ...)
+		end
+
+		obj[('fmt_%s'):format(x.name)] = function()
+			return log_at_level(i, x, function(...)
+				local passed = { ... }
+				local fmt = table.remove(passed, 1)
+				local inspected = {}
+				for _, v in ipairs(passed) do
+					table.insert(inspected, vim.inspect(v))
+				end
+				return string.format(fmt, unpack(inspected))
+			end)
+		end
+	end
+end
+
+log.new(default_config, true)
+-- }}}
+
+return log

--- a/tests/core/effect_spec.lua
+++ b/tests/core/effect_spec.lua
@@ -1,65 +1,154 @@
+package.path = '../../../tests/?.lua;' .. package.path
+
 local Effect = require('react.core.effect')
-local Signal = require('react.core.signal')
+local Stack = require('react.util.stack')
+
+local core = require('react.core')
+local counter = require('tests.util.counter')
+local errors = require('react.core.effect-error-messages')
+
+local create_signal = core.create_signal
 
 describe('effect::', function()
-    it('throws when callback if not passed', function()
-        assert.has_error(function()
-            Effect:new('hello')
-        end)
+	before_each(function()
+		Effect.context = Stack:new()
+	end)
 
-        assert.has_error(function()
-            Effect:new()
-        end)
+	it('throws when callback function is not passed', function()
+		assert.has_error(function()
+			Effect:new('hello')
+		end)
 
-        assert.error_matches(function()
-            Effect:new()
-        end, 'Callback function should be passed to effect')
-    end)
+		assert.has_error(function()
+			Effect:new()
+		end)
 
-    it('callback runs on dispatch', function()
-        local got_callback = false
+		assert.error_matches(function()
+			Effect:new()
+		end, 'Callback function should be passed to effect')
+	end)
 
-        local effect = Effect:new(function()
-            got_callback = true
-        end)
+	it('callback runs on dispatch', function()
+		local count_render, get_count = counter()
 
-        effect:dispatch()
+		local effect = Effect:new(function()
+			count_render()
+		end)
 
-        assert.equal(true, got_callback)
-    end)
+		effect:dispatch()
 
-    it('adds signal to the effect on use', function()
-        local signal1 = Signal:new()
-        local signal2 = Signal:new()
+		assert.equal(1, get_count())
+	end)
 
-        local effect = Effect:new(function()
-            signal1:read()
-            signal2:read()
-        end)
+	it('adds effect/effects to the context in the correct order', function()
+		local effect_1, effect_2, effect_3
 
-        effect:dispatch()
+		effect_1 = Effect:new(function()
+			assert.same(1, #Effect.context.stack)
+			assert.same(effect_1, Effect.context.stack[1])
 
-        assert.equal(2, effect.signals:length())
-        assert.equal(signal1, effect.signals:get(1))
-        assert.equal(signal2, effect.signals:get(2))
-    end)
+			effect_2 = Effect:new(function()
+				assert.same(2, #Effect.context.stack)
+				assert.same(effect_1, Effect.context.stack[1])
+				assert.same(effect_2, Effect.context.stack[2])
 
-    it('unsubscribes signals', function ()
-        local signal1 = Signal:new()
-        local signal2 = Signal:new()
-        local signal3 = Signal:new()
+				effect_3 = Effect:new(function()
+					assert.same(3, #Effect.context.stack)
+					assert.same(effect_1, Effect.context.stack[1])
+					assert.same(effect_2, Effect.context.stack[2])
+					assert.same(effect_3, Effect.context.stack[3])
+				end)
 
-        local effect = Effect:new(function()
-            signal1:read()
-            signal2:read()
-            signal3:read()
-        end)
+				effect_3:dispatch()
+			end)
 
-        effect:dispatch()
+			effect_2:dispatch()
+		end)
 
-        assert.equal(3, effect.signals:length())
+		effect_1:dispatch()
+	end)
 
-        effect:unsubscribe_signals()
-        assert.equal(0, effect.signals:length())
-    end)
+	it('first render status should be true on the initial render', function()
+		local signal, set_signal = create_signal(0)
+		local effect
+		local expected_first_time = true
+
+		effect = Effect:new(function()
+			local _ = signal()
+			assert.equal(expected_first_time, effect.first_render)
+		end)
+
+
+		effect:dispatch()
+
+		expected_first_time = false
+		assert.equal(expected_first_time, effect.first_render)
+
+		set_signal(1)
+		assert.equal(expected_first_time, effect.first_render)
+	end)
+
+	it('effect increases the pointer on signal request', function()
+		local effect
+		local signal_1, signal_2
+
+		local expected_signal_pointer = 1
+
+		effect = Effect:new(function()
+			signal_1 = create_signal(0)
+			signal_2 = create_signal(0)
+
+			signal_1()
+			signal_2()
+
+			assert.equal(expected_signal_pointer, effect.signal_pointer)
+		end)
+
+		effect:dispatch()
+
+		expected_signal_pointer = 3
+		effect:dispatch()
+	end)
+
+	it('throws when requesting more signals than registered', function()
+		local count_render, get_count = counter()
+
+		local effect = Effect:new(function()
+			local _ = create_signal(0)
+			local _ = create_signal(0)
+			local _ = create_signal(0)
+
+			--  on the re-render, this requests a new signal
+			if get_count() > 1 then
+				local _ = create_signal(0)
+			end
+
+			count_render()
+		end)
+
+		effect:dispatch()
+
+		assert.error_matches(function()
+			effect:dispatch()
+		end, errors.INVALID_SIGNAL_CREATION)
+	end)
+
+	it('unsubscribes signals from effect', function()
+		local signal1 = create_signal(1)
+		local signal2 = create_signal(1)
+		local signal3 = create_signal(1)
+
+		local effect = Effect:new(function()
+			signal1()
+			signal2()
+			signal3()
+		end)
+
+		effect:dispatch()
+
+		assert.equal(3, effect.signals:length())
+
+		effect:unsubscribe_signals()
+		assert.equal(0, effect.signals:length())
+	end)
 end)

--- a/tests/core/effect_spec.lua
+++ b/tests/core/effect_spec.lua
@@ -1,5 +1,3 @@
-package.path = '../../../tests/?.lua;' .. package.path
-
 local Effect = require('react.core.effect')
 local Stack = require('react.util.stack')
 

--- a/tests/core/init_spec.lua
+++ b/tests/core/init_spec.lua
@@ -1,5 +1,4 @@
 local Effect = require('react.core.effect')
-local Stack = require('react.util.stack')
 
 local counter = require('tests.util.counter')
 local core = require('react.core')

--- a/tests/core/init_spec.lua
+++ b/tests/core/init_spec.lua
@@ -1,145 +1,49 @@
+local Effect = require('react.core.effect')
+local Stack = require('react.util.stack')
+
+local counter = require('tests.util.counter')
 local core = require('react.core')
 
 local create_signal = core.create_signal
 local create_effect = core.create_effect
 
 describe('core::', function()
-    describe('signal::', function()
-        it('correctly sets initial value', function()
-            local num = create_signal(10)
-            local str = create_signal('hello world')
-            local bool = create_signal(true)
-            local tbl = create_signal({ name = 's1n7ax' })
+	describe('signal::', function()
+		it('create_signal should return read and write function', function()
+			local signal, set_signal = create_signal(10)
+			assert('function', type(signal))
+			assert('function', type(set_signal))
+		end)
 
-            assert.same(10, num())
-            assert.same('hello world', str())
-            assert.same(true, bool())
-            assert.same({ name = 's1n7ax' }, tbl())
-        end)
+		it('read function should return the value', function()
+			local signal = create_signal(10)
+			assert(10, signal)
+		end)
 
-        it('correctly changes the existing value', function()
-            local signal, set_signal = create_signal(10)
-            assert.same(10, signal())
+		it('write function should update the value', function()
+			local signal, set_signal = create_signal(10)
+			assert(10, signal)
 
-            set_signal('hello world')
-            assert.same('hello world', signal())
+			set_signal(20)
+			assert(20, signal)
+		end)
+	end)
 
-            set_signal(true)
-            assert.same(true, signal())
+	describe('effect::', function()
+		it('should trigger the initial render on creation', function()
+			local count, get_count = counter()
 
-            set_signal({ name = 's1n7ax' })
-            assert.same({ name = 's1n7ax' }, signal())
-        end)
+			create_effect(function()
+				count()
+			end)
 
-        it('signal change re-call effect', function()
-            local signal, set_signal = create_signal(10)
-            local current_value = nil
+			assert.equal(1, get_count())
+		end)
 
-            create_effect(function()
-                current_value = signal()
-            end)
+		it('should return the effect on creation', function()
+			local effect = create_effect(function() end)
 
-            assert.same(10, current_value)
-
-            set_signal('hello world')
-            assert.same('hello world', current_value)
-
-            set_signal(true)
-            assert.same(true, current_value)
-
-            set_signal({ name = 's1n7ax' })
-            assert.same({ name = 's1n7ax' }, current_value)
-        end)
-
-        it('signal can not be created within an effect', function()
-            create_effect(function()
-                assert.has_error(function()
-                    local _, _ = create_signal(10)
-                end)
-            end)
-
-            create_effect(function()
-                assert.error_matches(function()
-                    local _, _ = create_signal(10)
-                end, 'Creating signals or stores within an effect or component is not yet supported')
-            end)
-        end)
-    end)
-
-    describe('effect::', function()
-        it('signal only triggers the effect that uses the signal', function()
-            local signal1, set_signal1 = create_signal(10)
-            local signal2 = create_signal(10)
-
-            local signal1_value = nil
-            local signal2_value = nil
-
-            create_effect(function()
-                signal1_value = signal1()
-            end)
-
-            create_effect(function()
-                signal2_value = signal2()
-            end)
-
-            set_signal1('hello world')
-
-            assert.same(signal1_value, 'hello world')
-            assert.same(signal2_value, 10)
-        end)
-
-        it('signal only triggers the effect that uses the signal when nested', function()
-            local signal1, set_signal1 = create_signal(10)
-            local signal2, set_signal2 = create_signal(20)
-            local signal3, set_signal3 = create_signal(30)
-
-            local curr_signal1 = nil
-            local curr_signal2 = nil
-            local curr_signal3 = nil
-
-            create_effect(function()
-                curr_signal1 = signal1()
-
-                create_effect(function()
-                    curr_signal2 = signal2()
-
-                    create_effect(function()
-                        curr_signal3 = signal3()
-                    end)
-                end)
-            end)
-
-            assert.same(10, curr_signal1)
-            assert.same(20, curr_signal2)
-            assert.same(30, curr_signal3)
-
-            set_signal3(signal3() + 1)
-            assert.same(31, curr_signal3)
-
-            set_signal2(signal2() + 1)
-            assert.same(21, curr_signal2)
-
-            set_signal1(signal1() + 1)
-            assert.same(11, curr_signal1)
-        end)
-
-        it('signal can be unsubscribed', function()
-            local signal, set_signal = create_signal(10)
-
-            local signal_value = nil
-
-            local effect = create_effect(function()
-                signal_value = signal()
-            end)
-
-            assert.same(10, signal_value)
-
-            set_signal('hello')
-            assert.same('hello', signal_value)
-
-            effect:unsubscribe_signals()
-            set_signal('world')
-            assert.same('hello', signal_value)
-        end)
-    end)
+			assert.is_true(getmetatable(effect) == Effect)
+		end)
+	end)
 end)

--- a/tests/core/signal_spec.lua
+++ b/tests/core/signal_spec.lua
@@ -1,42 +1,202 @@
 local Effect = require('react.core.effect')
 local Signal = require('react.core.signal')
 
+local counter = require('tests.util.counter')
+
 describe('signal::', function()
-	it('throws when initialized inside effect', function()
+	it('correctly sets initial value', function()
+		local num = Signal:new(10)
+		assert.equal(10, num:read())
+
+		local str = Signal:new('hello world')
+		assert.equal('hello world', str:read())
+
+		local bool = Signal:new(true)
+		assert.equal(true, bool:read())
+
+		local tbl = Signal:new({ name = 's1n7ax' })
+		assert.same({ name = 's1n7ax' }, tbl:read())
+	end)
+
+	it('correctly changes the existing value', function()
+		local signal = Signal:new(10)
+		assert.same(10, signal:read())
+
+		signal:write('hello world')
+		assert.same('hello world', signal:read())
+
+		signal:write(true)
+		assert.same(true, signal:read())
+
+		signal:write({ name = 's1n7ax' })
+		assert.same({ name = 's1n7ax' }, signal:read())
+	end)
+
+	it('can be initialized outside effect', function()
+		local signal = Signal:new(10)
+		assert.equal(10, signal:read())
+	end)
+
+	it('can be initialized inside effect', function()
 		local effect = Effect:new(function()
-			assert.has_error(function()
-				Signal:new(0)
-			end)
+			local signal = Signal:new(10)
+			assert(10, signal:read())
 		end)
 
 		effect:dispatch()
 	end)
 
-	it('readable & writeable outside of effects', function()
+	it('does not register effect on read outside effect', function()
+		local signal = Signal:new(10)
+		signal:read()
+		assert.equal(0, signal.publisher:length())
+	end)
+
+	it('register effect on read inside effect', function()
+		Effect:new(function()
+			local signal_1 = Signal:new(10)
+			local signal_2 = Signal:new(10)
+			local signal_3 = Signal:new(10)
+
+			signal_1:read()
+			signal_2:read()
+
+			assert.equal(1, signal_1.publisher:length())
+			assert.equal(1, signal_2.publisher:length())
+			assert.equal(0, signal_3.publisher:length())
+		end):dispatch()
+
+		local signal_1 = Signal:new(10)
+		local signal_2 = Signal:new(10)
+		local signal_3 = Signal:new(10)
+		Effect:new(function()
+			signal_1:read()
+			signal_2:read()
+
+			assert.equal(1, signal_1.publisher:length())
+			assert.equal(1, signal_2.publisher:length())
+			assert.equal(0, signal_3.publisher:length())
+		end):dispatch()
+	end)
+
+	it('effect is registered only once when same signal is used multiple times', function()
+		Effect:new(function()
+			local signal = Signal:new(10)
+
+			signal:read()
+			signal:read()
+			signal:read()
+
+			assert.equal(1, signal.publisher:length())
+		end):dispatch()
+
+		local signal = Signal:new(10)
+		Effect:new(function()
+			signal:read()
+			signal:read()
+			signal:read()
+		end):dispatch()
+		assert.equal(1, signal.publisher:length())
+	end)
+
+	it('re-render the effect on write', function()
+		local count, get_count = counter()
 		local signal = Signal:new(10)
 
-		assert.equal(10, signal:read())
+		Effect:new(function()
+			signal:read()
+			count()
+		end):dispatch()
 
-		signal:write(20)
-		assert.equal(20, signal:read())
+		assert.equal(1, get_count())
+
+		signal:write(11)
+		assert.equal(2, get_count())
+	end)
+
+	it('signal change is available in effect', function()
+		local signal = Signal:new(10)
+		local current_value = nil
+
+		Effect:new(function()
+			current_value = signal:read()
+		end):dispatch()
+
+		assert.same(10, current_value)
+
+		signal:write('hello world')
+		assert.same('hello world', current_value)
+
+		signal:write(true)
+		assert.same(true, current_value)
+
+		signal:write({ name = 's1n7ax' })
+		assert.same({ name = 's1n7ax' }, current_value)
+	end)
+
+	it('does not re-render when not used', function()
+		local signal
+
+		Effect:new(function()
+			signal = Signal:new(10)
+		end):dispatch()
 
 		assert.equal(0, signal.publisher:length())
 	end)
 
-	it('multiple signal reads in same effect should only register once', function()
-		local signal = Signal:new(10)
+	it('signal returns the initially created signal on re-render',
+		function()
+			local signal_1, signal_2, signal_3
 
-		local effect = Effect:new(function()
-			signal:read()
-			signal:read()
-			signal:read()
-		end)
+			Effect:new(function()
+				signal_1 = Signal:new(10)
+				signal_2 = Signal:new(20)
+				signal_3 = Signal:new(30)
+			end):dispatch()
 
-		effect:dispatch()
-		assert.equal(1, signal.publisher:length())
-	end)
+			assert.same(10, signal_1:get_value())
+			assert.same(20, signal_2:get_value())
+			assert.same(30, signal_3:get_value())
+
+			signal_1:write(signal_1:get_value() + 1)
+			signal_2:write(signal_2:get_value() + 1)
+			signal_3:write(signal_3:get_value() + 1)
+
+			assert.same(11, signal_1:get_value())
+			assert.same(21, signal_2:get_value())
+			assert.same(31, signal_3:get_value())
+		end
+	)
 
 	it('after unsubscribe, effect should be removed from signal', function()
+		local signal_1 = Signal:new(10)
+		local signal_2 = Signal:new(10)
+		local render_count = 0
+
+		local effect = Effect:new(function()
+			signal_1:read()
+			signal_2:read()
+
+			render_count = render_count + 1
+		end)
+		effect:dispatch()
+
+		assert.equal(1, render_count)
+
+		signal_1:write(11)
+		assert.equal(2, render_count)
+
+		signal_2:write(11)
+		assert.equal(3, render_count)
+
+		effect:unsubscribe_signals()
+
+		signal_1:write(12)
+		signal_2:write(12)
+		assert.equal(3, render_count)
+	end)
+
+	it('adds signal to the effect on use', function()
 		local signal1 = Signal:new(10)
 		local signal2 = Signal:new(10)
 
@@ -47,11 +207,6 @@ describe('signal::', function()
 
 		effect:dispatch()
 
-		assert.equal(1, signal1.publisher:length())
-		assert.equal(1, signal2.publisher:length())
-
-		effect:unsubscribe_signals()
-		assert.equal(0, signal1.publisher:length())
-		assert.equal(0, signal2.publisher:length())
+		assert.equal(2, effect.signals:length())
 	end)
 end)

--- a/tests/util/counter.lua
+++ b/tests/util/counter.lua
@@ -1,0 +1,13 @@
+return function(opt)
+	local by = opt and opt.by or 1
+
+	local count = 0
+
+	return function()
+		local prev_count = count
+		count = count + by
+		return prev_count
+	end, function()
+		return count
+	end
+end


### PR DESCRIPTION
Now following code is possible.

```
create_effect(function()
    local name, set_name = create_signal('s1n7ax')
end)
```

Note that you can now create signals inside the effect function. On re-render, it acts like a react hook. Instead of re creating a new signal on each re-render, it retrieves the initially created signal.

Similarly, you should not create effects within loops, conditions, or nested functions. Every signal should be defined within directly inside the effect or component.